### PR TITLE
Fix (ci): Use `GITHUB_TOKEN` to avoid hitting Github API rate limits in builds

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -91,6 +91,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -98,6 +100,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -106,6 +110,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -113,12 +119,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -127,6 +137,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
@@ -218,6 +230,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -225,6 +239,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -233,6 +249,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -240,12 +258,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -254,6 +276,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -344,6 +368,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -351,6 +377,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -359,6 +387,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -366,12 +396,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -380,6 +414,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -470,6 +506,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -477,6 +515,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -485,6 +525,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -492,12 +534,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -506,6 +552,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -596,6 +644,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -603,6 +653,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -611,6 +663,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -618,12 +672,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -632,6 +690,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -722,6 +782,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -729,6 +791,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -737,6 +801,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -744,12 +810,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -758,6 +828,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -848,6 +920,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -855,6 +929,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -863,6 +939,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -870,12 +948,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -884,6 +966,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -974,6 +1058,8 @@ jobs:
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -981,6 +1067,8 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -989,6 +1077,8 @@ jobs:
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -996,12 +1086,16 @@ jobs:
         tags: |
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         context: ${{ env.VARIANT_BUILD_DIR }}
         platforms: linux/amd64
@@ -1010,6 +1104,8 @@ jobs:
           ${{ github.repository }}:${{ env.VARIANT_TAG }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF }}
           ${{ github.repository }}:${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -104,6 +104,8 @@ $VARIANTS | % {
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: `${{ secrets.GITHUB_TOKEN }}
       with:
         context: `${{ env.VARIANT_BUILD_DIR }}
         platforms: $( $_['_metadata']['platforms'] -join ',' )
@@ -111,6 +113,8 @@ $VARIANTS | % {
         tags: |
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF }}
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=`${{ secrets.GITHUB_TOKEN }}"
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -119,6 +123,8 @@ $VARIANTS | % {
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: `${{ secrets.GITHUB_TOKEN }}
       with:
         context: `${{ env.VARIANT_BUILD_DIR }}
         platforms: $( $_['_metadata']['platforms'] -join ',' )
@@ -126,12 +132,16 @@ $VARIANTS | % {
         tags: |
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF }}
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=`${{ secrets.GITHUB_TOKEN }}"
         cache-to: type=local,dest=/tmp/.buildx-cache
 
     - name: Build and push (release)
       id: docker_build_release
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
+      env:
+        GITHUB_TOKEN: `${{ secrets.GITHUB_TOKEN }}
       with:
         context: `${{ env.VARIANT_BUILD_DIR }}
         platforms: $( $_['_metadata']['platforms'] -join ',' )
@@ -140,6 +150,8 @@ $VARIANTS | % {
           `${{ github.repository }}:`${{ env.VARIANT_TAG }}
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF }}
           `${{ github.repository }}:`${{ env.VARIANT_TAG_WITH_REF_AND_SHA_SHORT }}
+        secrets: |
+          "GITHUB_TOKEN=`${{ secrets.GITHUB_TOKEN }}"
 
 "@
 

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -1,16 +1,20 @@
 @"
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM $( $VARIANT['_metadata']['distro'] ):$( $VARIANT['_metadata']['distro_version'] )
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on `$BUILDPLATFORM, building for `$TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache `$DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@$( $VARIANT['_metadata']['package_version'] ) --unsafe-perm \
+    && GITHUB_TOKEN=`$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@$( $VARIANT['_metadata']['package_version'] ) --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=`$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del `$DEPS
 

--- a/variants/v4.6.1-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.6.1 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.6.1 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.7.1-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.7.1 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.7.1 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.8.3-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.8.3 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.8.3 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.8.3 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.8.3 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.8.3 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 

--- a/variants/v4.9.1-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-alpine-3.15/Dockerfile
@@ -1,15 +1,19 @@
+# syntax=docker/dockerfile:1
+# The syntax=docker/dockerfile:1 line above is needed for passing secrets to the build
+
 FROM alpine:3.15
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
     && apk add --no-cache $DEPS \
     && apk add --no-cache npm nodejs \
     && npm config set python python3 \
-    && npm install --global code-server@4.9.1 --unsafe-perm \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.9.1 --unsafe-perm \
     # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
-    && cd /usr/local/lib/node_modules/code-server/lib/vscode && npm install --legacy-peer-deps \
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
     && code-server --version \
     && apk del $DEPS
 


### PR DESCRIPTION
Fixes `vscode-ripgrep` hitting rate limits with `403`.