### PR TITLE
Fix: Remove default `code-server` config file created when extensions are installed

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -61,6 +61,8 @@ RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
 RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 ENV LANG=en_US.UTF-8
 USER user
@@ -123,6 +125,8 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
         }
     }
 @"
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 # Restore user
 USER user

--- a/variants/v4.6.1-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-alpine-3.15/Dockerfile
@@ -58,6 +58,8 @@ RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
 RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 ENV LANG=en_US.UTF-8
 USER user

--- a/variants/v4.7.1-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-alpine-3.15/Dockerfile
@@ -58,6 +58,8 @@ RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
 RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 ENV LANG=en_US.UTF-8
 USER user

--- a/variants/v4.8.3-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-alpine-3.15/Dockerfile
@@ -58,6 +58,8 @@ RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
 RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 ENV LANG=en_US.UTF-8
 USER user

--- a/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/Dockerfile
@@ -40,6 +40,8 @@ RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 
 # Install extensions
 USER user
 RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 # Restore user
 USER user

--- a/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/Dockerfile
@@ -40,6 +40,8 @@ RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 
 # Install extensions
 USER user
 RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 # Restore user
 USER user

--- a/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/Dockerfile
@@ -40,6 +40,8 @@ RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 
 # Install extensions
 USER user
 RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 # Restore user
 USER user

--- a/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/Dockerfile
@@ -40,6 +40,8 @@ RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 
 # Install extensions
 USER user
 RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 # Restore user
 USER user

--- a/variants/v4.9.1-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-alpine-3.15/Dockerfile
@@ -58,6 +58,8 @@ RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
 RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+# Remove the default config file created when extensions are installed
+RUN rm -v ~/.config/code-server/config.yaml
 
 ENV LANG=en_US.UTF-8
 USER user


### PR DESCRIPTION
This ensures the config file is generated fresh on container startup.