### PR TITLE
Fix (docker): Fix `docker` variants to cleanup `/var/run/docker.pid` when container is stopped and started

### DIFF
--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -10,6 +10,7 @@ if ($VARIANT['_metadata']['base_tag']) {
         if ($c -eq 'docker') {
 @'
 echo "Starting dockerd"
+sudo rm -fv /var/run/docker.pid
 sudo dockerd &
 
 '@

--- a/variants/v4.6.1-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 echo "Starting dockerd"
+sudo rm -fv /var/run/docker.pid
 sudo dockerd &
 echo "Starting code-server"
 exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check

--- a/variants/v4.7.1-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 echo "Starting dockerd"
+sudo rm -fv /var/run/docker.pid
 sudo dockerd &
 echo "Starting code-server"
 exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check

--- a/variants/v4.8.3-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 echo "Starting dockerd"
+sudo rm -fv /var/run/docker.pid
 sudo dockerd &
 echo "Starting code-server"
 exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check

--- a/variants/v4.9.1-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 echo "Starting dockerd"
+sudo rm -fv /var/run/docker.pid
 sudo dockerd &
 echo "Starting code-server"
 exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check


### PR DESCRIPTION
`dockerd` fails to start if `/var/run/docker.pid` already exists.