### PR TITLE
Enhancement: Add a default `code-server` `settings.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Dockerized [`code-server`](https://github.com/coder/code-server).
 
 Base variants do not contain additional tools. E.g. `v4.9.1-alpine-3.15`.
 
-Incremental variants contain additional tools. E.g. `v4.9.1-docker-alpine-3.15`:
+Incremental variants contain additional tools and their `code` extensions. E.g. `v4.9.1-docker-alpine-3.15`:
 
 - `docker`: [docker](https://docs.docker.com/engine/)
 - `docker-rootless`: [Rootless docker](https://docs.docker.com/engine/security/rootless/)
@@ -64,6 +64,7 @@ docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 - The default user is named `user` with UID `1000`. To escalate as `root`, use `sudo`.
 - Users should provision their own configuration files at entrypoint. Examples include dot files such as `~/.bash_aliases`, `~/.gitconfig`, and `code` configs such as `~/.local/share/code-server/User/keybindings.json` and `~/.local/share/code-server/User/settings.json`.
 - To ensure `bash-completion` works, ensure `/etc/profile.d/bash_completion.sh` is sourced by `~/.bashrc`. When `exec`ing into the container, use a login shell (E.g. `docker exec -it <container> bash -l`).
+- To install a custom version of a `code` extension, set `"extensions.autoCheckUpdates": true` in `settings.json`. Under `Extensions` view, click the extension's cogwheel and select `Install Another Version...`.
 
 ## Development
 

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -121,6 +121,14 @@ $VARIANTS_SHARED = @{
                     }
                 )
             }
+            'settings.json' = @{
+                common = $true
+                passes = @(
+                    @{
+                        variables = @{}
+                    }
+                )
+            }
         }
     }
 }

--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -61,6 +61,10 @@ RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
 RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
 "@
 }else {
     # Incremental build

--- a/generate/templates/README.md.ps1
+++ b/generate/templates/README.md.ps1
@@ -28,7 +28,7 @@ $(
 )
 Base variants do not contain additional tools. E.g. ``$( $VARIANTS | ? { $_['tag_as_latest'] } | Select-Object -ExpandProperty tag )``.
 
-Incremental variants contain additional tools. E.g. ``$( $VARIANTS | ? { $_['_metadata']['base_tag'] } | Select-Object -First 1 | Select-Object -ExpandProperty tag )``:
+Incremental variants contain additional tools and their ``code`` extensions. E.g. ``$( $VARIANTS | ? { $_['_metadata']['base_tag'] } | Select-Object -First 1 | Select-Object -ExpandProperty tag )``:
 
 - ``docker``: [docker](https://docs.docker.com/engine/)
 - ``docker-rootless``: [Rootless docker](https://docs.docker.com/engine/security/rootless/)
@@ -70,6 +70,7 @@ docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 - The default user is named `user` with UID `1000`. To escalate as `root`, use `sudo`.
 - Users should provision their own configuration files at entrypoint. Examples include dot files such as `~/.bash_aliases`, `~/.gitconfig`, and `code` configs such as `~/.local/share/code-server/User/keybindings.json` and `~/.local/share/code-server/User/settings.json`.
 - To ensure `bash-completion` works, ensure `/etc/profile.d/bash_completion.sh` is sourced by `~/.bashrc`. When `exec`ing into the container, use a login shell (E.g. `docker exec -it <container> bash -l`).
+- To install a custom version of a `code` extension, set `"extensions.autoCheckUpdates": true` in `settings.json`. Under `Extensions` view, click the extension's cogwheel and select `Install Another Version...`.
 
 ## Development
 

--- a/generate/templates/settings.json.ps1
+++ b/generate/templates/settings.json.ps1
@@ -1,0 +1,20 @@
+@"
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}
+"@

--- a/variants/v4.6.1-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-alpine-3.15/Dockerfile
@@ -59,6 +59,10 @@ RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
 
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
 # Remove the default code-server config file created when extensions are installed
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml

--- a/variants/v4.6.1-alpine-3.15/settings.json
+++ b/variants/v4.6.1-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1-docker-alpine-3.15/settings.json
+++ b/variants/v4.6.1-docker-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1-docker-rootless-alpine-3.15/settings.json
+++ b/variants/v4.6.1-docker-rootless-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-alpine-3.15/Dockerfile
@@ -59,6 +59,10 @@ RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
 
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
 # Remove the default code-server config file created when extensions are installed
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml

--- a/variants/v4.7.1-alpine-3.15/settings.json
+++ b/variants/v4.7.1-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-docker-alpine-3.15/settings.json
+++ b/variants/v4.7.1-docker-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-docker-rootless-alpine-3.15/settings.json
+++ b/variants/v4.7.1-docker-rootless-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-alpine-3.15/Dockerfile
@@ -59,6 +59,10 @@ RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
 
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
 # Remove the default code-server config file created when extensions are installed
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml

--- a/variants/v4.8.3-alpine-3.15/settings.json
+++ b/variants/v4.8.3-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-docker-alpine-3.15/settings.json
+++ b/variants/v4.8.3-docker-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-docker-rootless-alpine-3.15/settings.json
+++ b/variants/v4.8.3-docker-rootless-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/settings.json
+++ b/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/settings.json
+++ b/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/settings.json
+++ b/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/settings.json
+++ b/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-alpine-3.15/Dockerfile
@@ -59,6 +59,10 @@ RUN code-server --install-extension redhat.vscode-xml@0.18.0
 # yaml
 RUN code-server --install-extension redhat.vscode-yaml@1.9.1
 
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
 # Remove the default code-server config file created when extensions are installed
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml

--- a/variants/v4.9.1-alpine-3.15/settings.json
+++ b/variants/v4.9.1-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-docker-alpine-3.15/settings.json
+++ b/variants/v4.9.1-docker-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-docker-rootless-alpine-3.15/settings.json
+++ b/variants/v4.9.1-docker-rootless-alpine-3.15/settings.json
@@ -1,0 +1,16 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.startupEditor": "none",
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}


### PR DESCRIPTION
The default `settings.json` contains common-sense settings for docker images:
- Disable update checks for extensions
- Disable telemetry for `code` and extensions
- Disable Welcome page for extensions
- Disable What's New page for extensions