### PR TITLE
Enhancement: Remove the `alefragnani.Bookmarks` extension from all base variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -28,8 +28,6 @@ RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
 
 # Install common extensions
 USER user
-# bookmarks
-RUN code-server --install-extension alefragnani.Bookmarks@13.0.1
 # beautify - code formatter
 RUN code-server --install-extension hookyqr.beautify@1.4.11
 # docker

--- a/generate/templates/settings.json.ps1
+++ b/generate/templates/settings.json.ps1
@@ -4,10 +4,8 @@
   "extensions.autoUpdate": false,
   "extensions.ignoreRecommendations": true,
   "extensions.showRecommendationsOnlyOnDemand": true,
-
   "telemetry.enableTelemetry": false,
   "telemetry.telemetryLevel": "off",
-
   "workbench.iconTheme": "vscode-icons",
   "workbench.startupEditor": "none",
 

--- a/variants/v4.6.1-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-alpine-3.15/Dockerfile
@@ -25,8 +25,6 @@ RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
 
 # Install common extensions
 USER user
-# bookmarks
-RUN code-server --install-extension alefragnani.Bookmarks@13.0.1
 # beautify - code formatter
 RUN code-server --install-extension hookyqr.beautify@1.4.11
 # docker

--- a/variants/v4.7.1-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-alpine-3.15/Dockerfile
@@ -25,8 +25,6 @@ RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
 
 # Install common extensions
 USER user
-# bookmarks
-RUN code-server --install-extension alefragnani.Bookmarks@13.0.1
 # beautify - code formatter
 RUN code-server --install-extension hookyqr.beautify@1.4.11
 # docker

--- a/variants/v4.8.3-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-alpine-3.15/Dockerfile
@@ -25,8 +25,6 @@ RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
 
 # Install common extensions
 USER user
-# bookmarks
-RUN code-server --install-extension alefragnani.Bookmarks@13.0.1
 # beautify - code formatter
 RUN code-server --install-extension hookyqr.beautify@1.4.11
 # docker

--- a/variants/v4.9.1-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-alpine-3.15/Dockerfile
@@ -25,8 +25,6 @@ RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
 
 # Install common extensions
 USER user
-# bookmarks
-RUN code-server --install-extension alefragnani.Bookmarks@13.0.1
 # beautify - code formatter
 RUN code-server --install-extension hookyqr.beautify@1.4.11
 # docker


### PR DESCRIPTION
The `alefragnani.Bookmarks` extension is not very useful, since in most cases `code` already provides many other ways of code navigation, e.g. search, debug breakpoints, back and forward, go to, etc. Moreover the `alefragnani.Bookmarks` [still] does not provide a way to disable its `What's New` page, which will always display on a fresh instance of `code-server`.