### PR TITLE
Fix: Add anonymous volume for `docker` variants

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -99,6 +99,7 @@ RUN apk add --no-cache \
         zfs
 RUN apk add --no-cache docker
 RUN adduser user docker
+VOLUME /var/lib/docker
 
 # Install docker compose v2
 RUN apk add --no-cache docker-cli-compose

--- a/variants/v4.6.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-docker-alpine-3.15/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
         zfs
 RUN apk add --no-cache docker
 RUN adduser user docker
+VOLUME /var/lib/docker
 
 # Install docker compose v2
 RUN apk add --no-cache docker-cli-compose

--- a/variants/v4.7.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-docker-alpine-3.15/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
         zfs
 RUN apk add --no-cache docker
 RUN adduser user docker
+VOLUME /var/lib/docker
 
 # Install docker compose v2
 RUN apk add --no-cache docker-cli-compose

--- a/variants/v4.8.3-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-alpine-3.15/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
         zfs
 RUN apk add --no-cache docker
 RUN adduser user docker
+VOLUME /var/lib/docker
 
 # Install docker compose v2
 RUN apk add --no-cache docker-cli-compose

--- a/variants/v4.9.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-docker-alpine-3.15/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
         zfs
 RUN apk add --no-cache docker
 RUN adduser user docker
+VOLUME /var/lib/docker
 
 # Install docker compose v2
 RUN apk add --no-cache docker-cli-compose


### PR DESCRIPTION
Without this, `docker` variants will not be able to start with `--storage-driver overlay2`, since it will be overlay-in-overlay.