### PR TITLE
Enhancement: Use `ENTRYPOINT` instead of `CMD` for `/docker-entrypoint.sh`

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -380,5 +380,7 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]
+
 "@

--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -2,6 +2,12 @@
 #!/bin/sh
 set -eu
 
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
 '@
 
 if ($VARIANT['_metadata']['base_tag']) {
@@ -9,28 +15,28 @@ if ($VARIANT['_metadata']['base_tag']) {
     foreach ($c in $VARIANT['_metadata']['components']) {
         if ($c -eq 'docker') {
 @'
-echo "Starting dockerd"
-sudo rm -fv /var/run/docker.pid
-sudo dockerd &
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
 
 '@
         }
         if ($c -eq 'docker-rootless') {
 @'
-# Start rootless docker
-# See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
-# See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
-echo "Starting rootless dockerd"
-rootlesskit \
-    --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-    --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
-    --disable-host-loopback \
-    --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
-    --copy-up=/etc \
-    --copy-up=/run \
-    --propagation=rslave \
-    ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
-    dockerd &
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
 
 '@
         }
@@ -38,6 +44,10 @@ rootlesskit \
 }
 
 @'
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"
+
 '@

--- a/variants/v4.6.1-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-alpine-3.15/Dockerfile
@@ -73,4 +73,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.6.1-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-docker-alpine-3.15/Dockerfile
@@ -177,4 +177,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 set -eu
-echo "Starting dockerd"
-sudo rm -fv /var/run/docker.pid
-sudo dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-docker-rootless-alpine-3.15/Dockerfile
@@ -221,4 +221,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-docker-rootless-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker-rootless-alpine-3.15/docker-entrypoint.sh
@@ -1,18 +1,27 @@
 #!/bin/sh
 set -eu
-# Start rootless docker
-# See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
-# See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
-echo "Starting rootless dockerd"
-rootlesskit \
-    --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-    --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
-    --disable-host-loopback \
-    --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
-    --copy-up=/etc \
-    --copy-up=/run \
-    --propagation=rslave \
-    ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
-    dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-alpine-3.15/Dockerfile
@@ -73,4 +73,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.7.1-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-docker-alpine-3.15/Dockerfile
@@ -177,4 +177,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 set -eu
-echo "Starting dockerd"
-sudo rm -fv /var/run/docker.pid
-sudo dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-docker-rootless-alpine-3.15/Dockerfile
@@ -221,4 +221,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-docker-rootless-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker-rootless-alpine-3.15/docker-entrypoint.sh
@@ -1,18 +1,27 @@
 #!/bin/sh
 set -eu
-# Start rootless docker
-# See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
-# See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
-echo "Starting rootless dockerd"
-rootlesskit \
-    --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-    --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
-    --disable-host-loopback \
-    --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
-    --copy-up=/etc \
-    --copy-up=/run \
-    --propagation=rslave \
-    ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
-    dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-alpine-3.15/Dockerfile
@@ -73,4 +73,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-alpine-3.15/Dockerfile
@@ -177,4 +177,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 set -eu
-echo "Starting dockerd"
-sudo rm -fv /var/run/docker.pid
-sudo dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-alpine-3.15/Dockerfile
@@ -221,4 +221,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-docker-rootless-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker-rootless-alpine-3.15/docker-entrypoint.sh
@@ -1,18 +1,27 @@
 #!/bin/sh
 set -eu
-# Start rootless docker
-# See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
-# See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
-echo "Starting rootless dockerd"
-rootlesskit \
-    --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-    --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
-    --disable-host-loopback \
-    --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
-    --copy-up=/etc \
-    --copy-up=/run \
-    --propagation=rslave \
-    ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
-    dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/Dockerfile
@@ -52,4 +52,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-pwsh-7.0.13-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/Dockerfile
@@ -52,4 +52,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-pwsh-7.1.7-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/Dockerfile
@@ -52,4 +52,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-pwsh-7.2.8-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/Dockerfile
@@ -52,4 +52,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.8.3-pwsh-7.3.1-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-alpine-3.15/Dockerfile
@@ -73,4 +73,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.9.1-alpine-3.15/docker-entrypoint.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 set -eu
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-docker-alpine-3.15/Dockerfile
@@ -177,4 +177,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-docker-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker-alpine-3.15/docker-entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 set -eu
-echo "Starting dockerd"
-sudo rm -fv /var/run/docker.pid
-sudo dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-docker-rootless-alpine-3.15/Dockerfile
@@ -221,4 +221,5 @@ RUN chmod +x /docker-entrypoint.sh
 ENV LANG=en_US.UTF-8
 USER user
 WORKDIR /home/user
-CMD [ "/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-docker-rootless-alpine-3.15/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker-rootless-alpine-3.15/docker-entrypoint.sh
@@ -1,18 +1,27 @@
 #!/bin/sh
 set -eu
-# Start rootless docker
-# See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
-# See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
-echo "Starting rootless dockerd"
-rootlesskit \
-    --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-    --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
-    --disable-host-loopback \
-    --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
-    --copy-up=/etc \
-    --copy-up=/run \
-    --propagation=rslave \
-    ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
-    dockerd &
-echo "Starting code-server"
-exec code-server --bind-addr 0.0.0.0:8080 --disable-telemetry --disable-update-check
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"


### PR DESCRIPTION
This allow the `docker run` command to be most natural. See: https://github.com/docker-library/official-images#consistency