### PR TITLE
Enhancement: Symlink `code` to `code-server` to allow `code` commands to work seamlessly

### DIFF
--- a/generate/templates/Dockerfile.ps1
+++ b/generate/templates/Dockerfile.ps1
@@ -373,6 +373,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.6.1-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-alpine-3.15/Dockerfile
@@ -66,6 +66,10 @@ COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/se
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.6.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-docker-alpine-3.15/Dockerfile
@@ -170,6 +170,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.6.1-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.6.1-docker-rootless-alpine-3.15/Dockerfile
@@ -214,6 +214,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.7.1-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-alpine-3.15/Dockerfile
@@ -66,6 +66,10 @@ COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/se
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.7.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-docker-alpine-3.15/Dockerfile
@@ -170,6 +170,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.7.1-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.7.1-docker-rootless-alpine-3.15/Dockerfile
@@ -214,6 +214,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-alpine-3.15/Dockerfile
@@ -66,6 +66,10 @@ COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/se
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-alpine-3.15/Dockerfile
@@ -170,6 +170,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-pwsh-7.0.13-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-pwsh-7.0.13-alpine-3.15/Dockerfile
@@ -210,6 +210,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-pwsh-7.1.7-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-pwsh-7.1.7-alpine-3.15/Dockerfile
@@ -210,6 +210,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-pwsh-7.2.8-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-pwsh-7.2.8-alpine-3.15/Dockerfile
@@ -210,6 +210,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-pwsh-7.3.1-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-pwsh-7.3.1-alpine-3.15/Dockerfile
@@ -210,6 +210,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-alpine-3.15/Dockerfile
@@ -214,6 +214,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-rootless-pwsh-7.0.13-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-pwsh-7.0.13-alpine-3.15/Dockerfile
@@ -254,6 +254,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-rootless-pwsh-7.1.7-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-pwsh-7.1.7-alpine-3.15/Dockerfile
@@ -254,6 +254,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-rootless-pwsh-7.2.8-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-pwsh-7.2.8-alpine-3.15/Dockerfile
@@ -254,6 +254,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.8.3-docker-rootless-pwsh-7.3.1-alpine-3.15/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-pwsh-7.3.1-alpine-3.15/Dockerfile
@@ -254,6 +254,10 @@ RUN code-server --install-extension ms-vscode.powershell@2021.12.0
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.9.1-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-alpine-3.15/Dockerfile
@@ -66,6 +66,10 @@ COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/se
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.9.1-docker-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-docker-alpine-3.15/Dockerfile
@@ -170,6 +170,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/variants/v4.9.1-docker-rootless-alpine-3.15/Dockerfile
+++ b/variants/v4.9.1-docker-rootless-alpine-3.15/Dockerfile
@@ -214,6 +214,10 @@ RUN set -eux; \
 USER user
 RUN rm -fv ~/.config/code-server/config.yaml
 
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
 USER root
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
This allows the well-used `code --install-extension` and other  well-known `code` commands to be used against `code-server` seamlessly.
