### PR TITLE
Chore (ci): Remove unneeded `['_metadata']['base_tag']` from variant objects

### DIFF
--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -33,24 +33,6 @@ $VARIANTS = @(
                     package_version = $variant['package_version']
                     distro = $variant['distro']
                     distro_version = $variant['distro_version']
-                    base_tag = if ($subVariant['components'].Count -eq 0) {
-                        '' # Base image has no base
-                    }elseif ($subVariant['components'].Count -eq 1) {
-                        # 1st incremental should point to base
-                        @(
-                            "v$( $variant['package_version'] )"
-                            $variant['distro']
-                            $variant['distro_version']
-                        ) -join '-'
-                    }else {
-                        # 2nd or greater incremental should point to prior incremental
-                        @(
-                            "v$( $variant['package_version'] )"
-                            $subVariant['components'][0..($subVariant['components'].Count - 2)]
-                            $variant['distro']
-                            $variant['distro_version']
-                        ) -join '-'
-                    }
                     platforms = 'linux/amd64'
                     components = $subVariant['components']
                     job_group_key = $variant['package_version']

--- a/generate/templates/docker-entrypoint.sh.ps1
+++ b/generate/templates/docker-entrypoint.sh.ps1
@@ -10,18 +10,16 @@ if [ "$1" = 'code-server' ]; then
 
 '@
 
-if ($VARIANT['_metadata']['base_tag']) {
-    # Incremental build
-    foreach ($c in $VARIANT['_metadata']['components']) {
-        if ($c -eq 'docker') {
+foreach ($c in $VARIANT['_metadata']['components']) {
+    if ($c -eq 'docker') {
 @'
     echo "Starting dockerd"
     sudo rm -fv /var/run/docker.pid
     sudo dockerd &
 
 '@
-        }
-        if ($c -eq 'docker-rootless') {
+    }
+    if ($c -eq 'docker-rootless') {
 @'
     # Start rootless docker
     # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
@@ -39,7 +37,6 @@ if ($VARIANT['_metadata']['base_tag']) {
         dockerd &
 
 '@
-        }
     }
 }
 


### PR DESCRIPTION
Should have been removed as part of #99
