### PR TITLE
Enhancement (ci): Remove `alpine-3.15` suffix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-16-1-alpine-3-15
+      id: prep-v4-16-1
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.16.1-alpine-3.15"
+        VARIANT="v4.16.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,52 +102,52 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.16.1-alpine-3.15 - Build (PRs)
+    - name: v4.16.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-alpine-3.15
+        context: variants/v4.16.1
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-alpine-3.15 - Build and push (master)
+    - name: v4.16.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-alpine-3.15
+        context: variants/v4.16.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-alpine-3.15 - Build and push (release)
+    - name: v4.16.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-alpine-3.15
+        context: variants/v4.16.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-16-1-docker-alpine-3-15
+      id: prep-v4-16-1-docker
       run: |
         set -e
 
@@ -160,7 +160,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.16.1-docker-alpine-3.15"
+        VARIANT="v4.16.1-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -170,51 +170,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.16.1-docker-alpine-3.15 - Build (PRs)
+    - name: v4.16.1-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-alpine-3.15
+        context: variants/v4.16.1-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-alpine-3.15 - Build and push (master)
+    - name: v4.16.1-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-alpine-3.15
+        context: variants/v4.16.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-alpine-3.15 - Build and push (release)
+    - name: v4.16.1-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-alpine-3.15
+        context: variants/v4.16.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-16-1-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-16-1-docker-go-1-20-8
       run: |
         set -e
 
@@ -227,7 +227,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.16.1-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.16.1-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -237,51 +237,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.16.1-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.16.1-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.16.1-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.16.1-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.16.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.16.1-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.16.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-16-1-docker-rootless-alpine-3-15
+      id: prep-v4-16-1-docker-rootless
       run: |
         set -e
 
@@ -294,7 +294,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.16.1-docker-rootless-alpine-3.15"
+        VARIANT="v4.16.1-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -304,51 +304,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.16.1-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.16.1-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-rootless-alpine-3.15
+        context: variants/v4.16.1-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.16.1-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-rootless-alpine-3.15
+        context: variants/v4.16.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.16.1-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-rootless-alpine-3.15
+        context: variants/v4.16.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-16-1-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -361,7 +361,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.16.1-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.16.1-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -371,45 +371,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.16.1-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.16.1-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.16.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.16.1-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.16.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.16.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.16.1-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.16.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.16.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-16-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -467,7 +467,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-15-0-alpine-3-15
+      id: prep-v4-15-0
       run: |
         set -e
 
@@ -480,7 +480,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.15.0-alpine-3.15"
+        VARIANT="v4.15.0"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -490,51 +490,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.15.0-alpine-3.15 - Build (PRs)
+    - name: v4.15.0 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-alpine-3.15
+        context: variants/v4.15.0
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-alpine-3.15 - Build and push (master)
+    - name: v4.15.0 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-alpine-3.15
+        context: variants/v4.15.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-alpine-3.15 - Build and push (release)
+    - name: v4.15.0 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-alpine-3.15
+        context: variants/v4.15.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-15-0-docker-alpine-3-15
+      id: prep-v4-15-0-docker
       run: |
         set -e
 
@@ -547,7 +547,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.15.0-docker-alpine-3.15"
+        VARIANT="v4.15.0-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -557,51 +557,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.15.0-docker-alpine-3.15 - Build (PRs)
+    - name: v4.15.0-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-alpine-3.15
+        context: variants/v4.15.0-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-alpine-3.15 - Build and push (master)
+    - name: v4.15.0-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-alpine-3.15
+        context: variants/v4.15.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-alpine-3.15 - Build and push (release)
+    - name: v4.15.0-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-alpine-3.15
+        context: variants/v4.15.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-15-0-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-15-0-docker-go-1-20-8
       run: |
         set -e
 
@@ -614,7 +614,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.15.0-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.15.0-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -624,51 +624,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.15.0-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.15.0-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.15.0-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.15.0-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.15.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.15.0-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.15.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-15-0-docker-rootless-alpine-3-15
+      id: prep-v4-15-0-docker-rootless
       run: |
         set -e
 
@@ -681,7 +681,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.15.0-docker-rootless-alpine-3.15"
+        VARIANT="v4.15.0-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -691,51 +691,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.15.0-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.15.0-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-rootless-alpine-3.15
+        context: variants/v4.15.0-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.15.0-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-rootless-alpine-3.15
+        context: variants/v4.15.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.15.0-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-rootless-alpine-3.15
+        context: variants/v4.15.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-15-0-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -748,7 +748,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.15.0-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.15.0-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -758,45 +758,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.15.0-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.15.0-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.15.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.15.0-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.15.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.15.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.15.0-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.15.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.15.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-15-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -854,7 +854,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-14-1-alpine-3-15
+      id: prep-v4-14-1
       run: |
         set -e
 
@@ -867,7 +867,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.14.1-alpine-3.15"
+        VARIANT="v4.14.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -877,51 +877,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.14.1-alpine-3.15 - Build (PRs)
+    - name: v4.14.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-alpine-3.15
+        context: variants/v4.14.1
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-alpine-3.15 - Build and push (master)
+    - name: v4.14.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-alpine-3.15
+        context: variants/v4.14.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-alpine-3.15 - Build and push (release)
+    - name: v4.14.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-alpine-3.15
+        context: variants/v4.14.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-14-1-docker-alpine-3-15
+      id: prep-v4-14-1-docker
       run: |
         set -e
 
@@ -934,7 +934,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.14.1-docker-alpine-3.15"
+        VARIANT="v4.14.1-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -944,51 +944,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.14.1-docker-alpine-3.15 - Build (PRs)
+    - name: v4.14.1-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-alpine-3.15
+        context: variants/v4.14.1-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-alpine-3.15 - Build and push (master)
+    - name: v4.14.1-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-alpine-3.15
+        context: variants/v4.14.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-alpine-3.15 - Build and push (release)
+    - name: v4.14.1-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-alpine-3.15
+        context: variants/v4.14.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-14-1-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-14-1-docker-go-1-20-8
       run: |
         set -e
 
@@ -1001,7 +1001,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.14.1-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.14.1-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1011,51 +1011,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.14.1-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.14.1-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.14.1-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.14.1-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.14.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.14.1-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.14.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-14-1-docker-rootless-alpine-3-15
+      id: prep-v4-14-1-docker-rootless
       run: |
         set -e
 
@@ -1068,7 +1068,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.14.1-docker-rootless-alpine-3.15"
+        VARIANT="v4.14.1-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1078,51 +1078,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.14.1-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.14.1-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-rootless-alpine-3.15
+        context: variants/v4.14.1-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.14.1-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-rootless-alpine-3.15
+        context: variants/v4.14.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.14.1-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-rootless-alpine-3.15
+        context: variants/v4.14.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-14-1-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -1135,7 +1135,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.14.1-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.14.1-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1145,45 +1145,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.14.1-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.14.1-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.14.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.14.1-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.14.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.14.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.14.1-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.14.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.14.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-14-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1241,7 +1241,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-13-0-alpine-3-15
+      id: prep-v4-13-0
       run: |
         set -e
 
@@ -1254,7 +1254,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.13.0-alpine-3.15"
+        VARIANT="v4.13.0"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1264,51 +1264,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.13.0-alpine-3.15 - Build (PRs)
+    - name: v4.13.0 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-alpine-3.15
+        context: variants/v4.13.0
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-alpine-3.15 - Build and push (master)
+    - name: v4.13.0 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-alpine-3.15
+        context: variants/v4.13.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-alpine-3.15 - Build and push (release)
+    - name: v4.13.0 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-alpine-3.15
+        context: variants/v4.13.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-13-0-docker-alpine-3-15
+      id: prep-v4-13-0-docker
       run: |
         set -e
 
@@ -1321,7 +1321,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.13.0-docker-alpine-3.15"
+        VARIANT="v4.13.0-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1331,51 +1331,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.13.0-docker-alpine-3.15 - Build (PRs)
+    - name: v4.13.0-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-alpine-3.15
+        context: variants/v4.13.0-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-alpine-3.15 - Build and push (master)
+    - name: v4.13.0-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-alpine-3.15
+        context: variants/v4.13.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-alpine-3.15 - Build and push (release)
+    - name: v4.13.0-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-alpine-3.15
+        context: variants/v4.13.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-13-0-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-13-0-docker-go-1-20-8
       run: |
         set -e
 
@@ -1388,7 +1388,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.13.0-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.13.0-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1398,51 +1398,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.13.0-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.13.0-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.13.0-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.13.0-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.13.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.13.0-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.13.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-13-0-docker-rootless-alpine-3-15
+      id: prep-v4-13-0-docker-rootless
       run: |
         set -e
 
@@ -1455,7 +1455,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.13.0-docker-rootless-alpine-3.15"
+        VARIANT="v4.13.0-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1465,51 +1465,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.13.0-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.13.0-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-rootless-alpine-3.15
+        context: variants/v4.13.0-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.13.0-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-rootless-alpine-3.15
+        context: variants/v4.13.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.13.0-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-rootless-alpine-3.15
+        context: variants/v4.13.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-13-0-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -1522,7 +1522,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.13.0-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.13.0-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1532,45 +1532,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.13.0-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.13.0-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.13.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.13.0-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.13.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.13.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.13.0-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.13.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.13.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-13-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1628,7 +1628,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-12-0-alpine-3-15
+      id: prep-v4-12-0
       run: |
         set -e
 
@@ -1641,7 +1641,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.12.0-alpine-3.15"
+        VARIANT="v4.12.0"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1651,51 +1651,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.12.0-alpine-3.15 - Build (PRs)
+    - name: v4.12.0 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-alpine-3.15
+        context: variants/v4.12.0
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-alpine-3.15 - Build and push (master)
+    - name: v4.12.0 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-alpine-3.15
+        context: variants/v4.12.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-alpine-3.15 - Build and push (release)
+    - name: v4.12.0 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-alpine-3.15
+        context: variants/v4.12.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-12-0-docker-alpine-3-15
+      id: prep-v4-12-0-docker
       run: |
         set -e
 
@@ -1708,7 +1708,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.12.0-docker-alpine-3.15"
+        VARIANT="v4.12.0-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1718,51 +1718,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.12.0-docker-alpine-3.15 - Build (PRs)
+    - name: v4.12.0-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-alpine-3.15
+        context: variants/v4.12.0-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-alpine-3.15 - Build and push (master)
+    - name: v4.12.0-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-alpine-3.15
+        context: variants/v4.12.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-alpine-3.15 - Build and push (release)
+    - name: v4.12.0-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-alpine-3.15
+        context: variants/v4.12.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-12-0-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-12-0-docker-go-1-20-8
       run: |
         set -e
 
@@ -1775,7 +1775,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.12.0-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.12.0-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1785,51 +1785,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.12.0-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.12.0-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.12.0-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.12.0-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.12.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.12.0-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.12.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-12-0-docker-rootless-alpine-3-15
+      id: prep-v4-12-0-docker-rootless
       run: |
         set -e
 
@@ -1842,7 +1842,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.12.0-docker-rootless-alpine-3.15"
+        VARIANT="v4.12.0-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1852,51 +1852,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.12.0-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.12.0-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-rootless-alpine-3.15
+        context: variants/v4.12.0-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.12.0-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-rootless-alpine-3.15
+        context: variants/v4.12.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.12.0-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-rootless-alpine-3.15
+        context: variants/v4.12.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-12-0-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -1909,7 +1909,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.12.0-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.12.0-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1919,45 +1919,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.12.0-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.12.0-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.12.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.12.0-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.12.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.12.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.12.0-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.12.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.12.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-12-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2015,7 +2015,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-11-0-alpine-3-15
+      id: prep-v4-11-0
       run: |
         set -e
 
@@ -2028,7 +2028,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.11.0-alpine-3.15"
+        VARIANT="v4.11.0"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2038,51 +2038,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.11.0-alpine-3.15 - Build (PRs)
+    - name: v4.11.0 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-alpine-3.15
+        context: variants/v4.11.0
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-alpine-3.15 - Build and push (master)
+    - name: v4.11.0 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-alpine-3.15
+        context: variants/v4.11.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-alpine-3.15 - Build and push (release)
+    - name: v4.11.0 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-alpine-3.15
+        context: variants/v4.11.0
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-11-0-docker-alpine-3-15
+      id: prep-v4-11-0-docker
       run: |
         set -e
 
@@ -2095,7 +2095,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.11.0-docker-alpine-3.15"
+        VARIANT="v4.11.0-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2105,51 +2105,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.11.0-docker-alpine-3.15 - Build (PRs)
+    - name: v4.11.0-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-alpine-3.15
+        context: variants/v4.11.0-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-alpine-3.15 - Build and push (master)
+    - name: v4.11.0-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-alpine-3.15
+        context: variants/v4.11.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-alpine-3.15 - Build and push (release)
+    - name: v4.11.0-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-alpine-3.15
+        context: variants/v4.11.0-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-11-0-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-11-0-docker-go-1-20-8
       run: |
         set -e
 
@@ -2162,7 +2162,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.11.0-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.11.0-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2172,51 +2172,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.11.0-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.11.0-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.11.0-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.11.0-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.11.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.11.0-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.11.0-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-11-0-docker-rootless-alpine-3-15
+      id: prep-v4-11-0-docker-rootless
       run: |
         set -e
 
@@ -2229,7 +2229,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.11.0-docker-rootless-alpine-3.15"
+        VARIANT="v4.11.0-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2239,51 +2239,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.11.0-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.11.0-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-rootless-alpine-3.15
+        context: variants/v4.11.0-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.11.0-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-rootless-alpine-3.15
+        context: variants/v4.11.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.11.0-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-rootless-alpine-3.15
+        context: variants/v4.11.0-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-11-0-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -2296,7 +2296,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.11.0-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.11.0-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2306,45 +2306,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.11.0-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.11.0-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.11.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.11.0-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.11.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.11.0-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.11.0-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.11.0-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.11.0-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-11-0-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2402,7 +2402,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-10-1-alpine-3-15
+      id: prep-v4-10-1
       run: |
         set -e
 
@@ -2415,7 +2415,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.10.1-alpine-3.15"
+        VARIANT="v4.10.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2425,51 +2425,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.10.1-alpine-3.15 - Build (PRs)
+    - name: v4.10.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-alpine-3.15
+        context: variants/v4.10.1
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-alpine-3.15 - Build and push (master)
+    - name: v4.10.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-alpine-3.15
+        context: variants/v4.10.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-alpine-3.15 - Build and push (release)
+    - name: v4.10.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-alpine-3.15
+        context: variants/v4.10.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-10-1-docker-alpine-3-15
+      id: prep-v4-10-1-docker
       run: |
         set -e
 
@@ -2482,7 +2482,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.10.1-docker-alpine-3.15"
+        VARIANT="v4.10.1-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2492,51 +2492,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.10.1-docker-alpine-3.15 - Build (PRs)
+    - name: v4.10.1-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-alpine-3.15
+        context: variants/v4.10.1-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-alpine-3.15 - Build and push (master)
+    - name: v4.10.1-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-alpine-3.15
+        context: variants/v4.10.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-alpine-3.15 - Build and push (release)
+    - name: v4.10.1-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-alpine-3.15
+        context: variants/v4.10.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-10-1-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-10-1-docker-go-1-20-8
       run: |
         set -e
 
@@ -2549,7 +2549,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.10.1-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.10.1-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2559,51 +2559,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.10.1-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.10.1-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.10.1-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.10.1-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.10.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.10.1-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.10.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-10-1-docker-rootless-alpine-3-15
+      id: prep-v4-10-1-docker-rootless
       run: |
         set -e
 
@@ -2616,7 +2616,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.10.1-docker-rootless-alpine-3.15"
+        VARIANT="v4.10.1-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2626,51 +2626,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.10.1-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.10.1-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-rootless-alpine-3.15
+        context: variants/v4.10.1-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.10.1-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-rootless-alpine-3.15
+        context: variants/v4.10.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.10.1-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-rootless-alpine-3.15
+        context: variants/v4.10.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-10-1-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -2683,7 +2683,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.10.1-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.10.1-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2693,45 +2693,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.10.1-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.10.1-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.10.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.10.1-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.10.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.10.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.10.1-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.10.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.10.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-10-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2789,7 +2789,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-9-1-alpine-3-15
+      id: prep-v4-9-1
       run: |
         set -e
 
@@ -2802,7 +2802,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.9.1-alpine-3.15"
+        VARIANT="v4.9.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2812,51 +2812,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.9.1-alpine-3.15 - Build (PRs)
+    - name: v4.9.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-alpine-3.15
+        context: variants/v4.9.1
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-alpine-3.15 - Build and push (master)
+    - name: v4.9.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-alpine-3.15
+        context: variants/v4.9.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-alpine-3.15 - Build and push (release)
+    - name: v4.9.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-alpine-3.15
+        context: variants/v4.9.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-9-1-docker-alpine-3-15
+      id: prep-v4-9-1-docker
       run: |
         set -e
 
@@ -2869,7 +2869,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.9.1-docker-alpine-3.15"
+        VARIANT="v4.9.1-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2879,51 +2879,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.9.1-docker-alpine-3.15 - Build (PRs)
+    - name: v4.9.1-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-alpine-3.15
+        context: variants/v4.9.1-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-alpine-3.15 - Build and push (master)
+    - name: v4.9.1-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-alpine-3.15
+        context: variants/v4.9.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-alpine-3.15 - Build and push (release)
+    - name: v4.9.1-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-alpine-3.15
+        context: variants/v4.9.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-9-1-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-9-1-docker-go-1-20-8
       run: |
         set -e
 
@@ -2936,7 +2936,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.9.1-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.9.1-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2946,51 +2946,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.9.1-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.9.1-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.9.1-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.9.1-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.9.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.9.1-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.9.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-9-1-docker-rootless-alpine-3-15
+      id: prep-v4-9-1-docker-rootless
       run: |
         set -e
 
@@ -3003,7 +3003,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.9.1-docker-rootless-alpine-3.15"
+        VARIANT="v4.9.1-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3013,51 +3013,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.9.1-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.9.1-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-rootless-alpine-3.15
+        context: variants/v4.9.1-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.9.1-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-rootless-alpine-3.15
+        context: variants/v4.9.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.9.1-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-rootless-alpine-3.15
+        context: variants/v4.9.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-9-1-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -3070,7 +3070,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.9.1-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.9.1-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3080,45 +3080,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.9.1-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.9.1-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.9.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.9.1-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.9.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.9.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.9.1-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.9.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.9.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-9-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -3176,7 +3176,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-3-alpine-3-15
+      id: prep-v4-8-3
       run: |
         set -e
 
@@ -3189,7 +3189,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.3-alpine-3.15"
+        VARIANT="v4.8.3"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3199,51 +3199,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.3-alpine-3.15 - Build (PRs)
+    - name: v4.8.3 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-alpine-3.15
+        context: variants/v4.8.3
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-alpine-3.15 - Build and push (master)
+    - name: v4.8.3 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-alpine-3.15
+        context: variants/v4.8.3
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-alpine-3.15 - Build and push (release)
+    - name: v4.8.3 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-alpine-3.15
+        context: variants/v4.8.3
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-3-docker-alpine-3-15
+      id: prep-v4-8-3-docker
       run: |
         set -e
 
@@ -3256,7 +3256,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.3-docker-alpine-3.15"
+        VARIANT="v4.8.3-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3266,51 +3266,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.3-docker-alpine-3.15 - Build (PRs)
+    - name: v4.8.3-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-alpine-3.15
+        context: variants/v4.8.3-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-alpine-3.15 - Build and push (master)
+    - name: v4.8.3-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-alpine-3.15
+        context: variants/v4.8.3-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-alpine-3.15 - Build and push (release)
+    - name: v4.8.3-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-alpine-3.15
+        context: variants/v4.8.3-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-3-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-8-3-docker-go-1-20-8
       run: |
         set -e
 
@@ -3323,7 +3323,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.3-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.8.3-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3333,51 +3333,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.3-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.8.3-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.8.3-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.8.3-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.8.3-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.8.3-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.8.3-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-3-docker-rootless-alpine-3-15
+      id: prep-v4-8-3-docker-rootless
       run: |
         set -e
 
@@ -3390,7 +3390,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.3-docker-rootless-alpine-3.15"
+        VARIANT="v4.8.3-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3400,51 +3400,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.3-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.8.3-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-rootless-alpine-3.15
+        context: variants/v4.8.3-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.8.3-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-rootless-alpine-3.15
+        context: variants/v4.8.3-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.8.3-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-rootless-alpine-3.15
+        context: variants/v4.8.3-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-8-3-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -3457,7 +3457,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.3-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.8.3-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3467,45 +3467,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.3-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.8.3-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.8.3-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.8.3-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.8.3-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.3-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.8.3-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.3-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.8.3-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-8-3-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -3563,7 +3563,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-7-1-alpine-3-15
+      id: prep-v4-7-1
       run: |
         set -e
 
@@ -3576,7 +3576,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.7.1-alpine-3.15"
+        VARIANT="v4.7.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3586,51 +3586,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.7.1-alpine-3.15 - Build (PRs)
+    - name: v4.7.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-alpine-3.15
+        context: variants/v4.7.1
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-alpine-3.15 - Build and push (master)
+    - name: v4.7.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-alpine-3.15
+        context: variants/v4.7.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-alpine-3.15 - Build and push (release)
+    - name: v4.7.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-alpine-3.15
+        context: variants/v4.7.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-7-1-docker-alpine-3-15
+      id: prep-v4-7-1-docker
       run: |
         set -e
 
@@ -3643,7 +3643,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.7.1-docker-alpine-3.15"
+        VARIANT="v4.7.1-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3653,51 +3653,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.7.1-docker-alpine-3.15 - Build (PRs)
+    - name: v4.7.1-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-alpine-3.15
+        context: variants/v4.7.1-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-alpine-3.15 - Build and push (master)
+    - name: v4.7.1-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-alpine-3.15
+        context: variants/v4.7.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-alpine-3.15 - Build and push (release)
+    - name: v4.7.1-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-alpine-3.15
+        context: variants/v4.7.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-7-1-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-7-1-docker-go-1-20-8
       run: |
         set -e
 
@@ -3710,7 +3710,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.7.1-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.7.1-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3720,51 +3720,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.7.1-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.7.1-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.7.1-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.7.1-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.7.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.7.1-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.7.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-7-1-docker-rootless-alpine-3-15
+      id: prep-v4-7-1-docker-rootless
       run: |
         set -e
 
@@ -3777,7 +3777,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.7.1-docker-rootless-alpine-3.15"
+        VARIANT="v4.7.1-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3787,51 +3787,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.7.1-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.7.1-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-rootless-alpine-3.15
+        context: variants/v4.7.1-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.7.1-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-rootless-alpine-3.15
+        context: variants/v4.7.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.7.1-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-rootless-alpine-3.15
+        context: variants/v4.7.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-7-1-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -3844,7 +3844,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.7.1-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.7.1-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3854,45 +3854,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.7.1-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.7.1-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.7.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.7.1-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.7.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.7.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.7.1-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.7.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.7.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-7-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -3950,7 +3950,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-6-1-alpine-3-15
+      id: prep-v4-6-1
       run: |
         set -e
 
@@ -3963,7 +3963,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.6.1-alpine-3.15"
+        VARIANT="v4.6.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -3973,51 +3973,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.6.1-alpine-3.15 - Build (PRs)
+    - name: v4.6.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-alpine-3.15
+        context: variants/v4.6.1
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-alpine-3.15 - Build and push (master)
+    - name: v4.6.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-alpine-3.15
+        context: variants/v4.6.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-alpine-3.15 - Build and push (release)
+    - name: v4.6.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-alpine-3.15
+        context: variants/v4.6.1
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-6-1-docker-alpine-3-15
+      id: prep-v4-6-1-docker
       run: |
         set -e
 
@@ -4030,7 +4030,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.6.1-docker-alpine-3.15"
+        VARIANT="v4.6.1-docker"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -4040,51 +4040,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.6.1-docker-alpine-3.15 - Build (PRs)
+    - name: v4.6.1-docker - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-alpine-3.15
+        context: variants/v4.6.1-docker
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-alpine-3.15 - Build and push (master)
+    - name: v4.6.1-docker - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-alpine-3.15
+        context: variants/v4.6.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-alpine-3.15 - Build and push (release)
+    - name: v4.6.1-docker - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-alpine-3.15
+        context: variants/v4.6.1-docker
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-6-1-docker-go-1-20-8-alpine-3-15
+      id: prep-v4-6-1-docker-go-1-20-8
       run: |
         set -e
 
@@ -4097,7 +4097,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.6.1-docker-go-1.20.8-alpine-3.15"
+        VARIANT="v4.6.1-docker-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -4107,51 +4107,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.6.1-docker-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.6.1-docker-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.6.1-docker-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.6.1-docker-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.6.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.6.1-docker-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-go-1.20.8-alpine-3.15
+        context: variants/v4.6.1-docker-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-6-1-docker-rootless-alpine-3-15
+      id: prep-v4-6-1-docker-rootless
       run: |
         set -e
 
@@ -4164,7 +4164,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.6.1-docker-rootless-alpine-3.15"
+        VARIANT="v4.6.1-docker-rootless"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -4174,51 +4174,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.6.1-docker-rootless-alpine-3.15 - Build (PRs)
+    - name: v4.6.1-docker-rootless - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-rootless-alpine-3.15
+        context: variants/v4.6.1-docker-rootless
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-rootless-alpine-3.15 - Build and push (master)
+    - name: v4.6.1-docker-rootless - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-rootless-alpine-3.15
+        context: variants/v4.6.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-rootless-alpine-3.15 - Build and push (release)
+    - name: v4.6.1-docker-rootless - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-rootless-alpine-3.15
+        context: variants/v4.6.1-docker-rootless
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15
+      id: prep-v4-6-1-docker-rootless-go-1-20-8
       run: |
         set -e
 
@@ -4231,7 +4231,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.6.1-docker-rootless-go-1.20.8-alpine-3.15"
+        VARIANT="v4.6.1-docker-rootless-go-1.20.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -4241,45 +4241,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.6.1-docker-rootless-go-1.20.8-alpine-3.15 - Build (PRs)
+    - name: v4.6.1-docker-rootless-go-1.20.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.6.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (master)
+    - name: v4.6.1-docker-rootless-go-1.20.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.6.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.6.1-docker-rootless-go-1.20.8-alpine-3.15 - Build and push (release)
+    - name: v4.6.1-docker-rootless-go-1.20.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.6.1-docker-rootless-go-1.20.8-alpine-3.15
+        context: variants/v4.6.1-docker-rootless-go-1.20.8
         platforms: linux/amd64
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-v4-6-1-docker-rootless-go-1-20-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/README.md
+++ b/README.md
@@ -10,63 +10,63 @@ Dockerized [`code-server`](https://github.com/coder/code-server).
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v4.16.1-alpine-3.15`, `:latest` | [View](variants/v4.16.1-alpine-3.15) |
-| `:v4.16.1-docker-alpine-3.15` | [View](variants/v4.16.1-docker-alpine-3.15) |
-| `:v4.16.1-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.16.1-docker-go-1.20.8-alpine-3.15) |
-| `:v4.16.1-docker-rootless-alpine-3.15` | [View](variants/v4.16.1-docker-rootless-alpine-3.15) |
-| `:v4.16.1-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.16.1-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.15.0-alpine-3.15` | [View](variants/v4.15.0-alpine-3.15) |
-| `:v4.15.0-docker-alpine-3.15` | [View](variants/v4.15.0-docker-alpine-3.15) |
-| `:v4.15.0-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.15.0-docker-go-1.20.8-alpine-3.15) |
-| `:v4.15.0-docker-rootless-alpine-3.15` | [View](variants/v4.15.0-docker-rootless-alpine-3.15) |
-| `:v4.15.0-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.15.0-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.14.1-alpine-3.15` | [View](variants/v4.14.1-alpine-3.15) |
-| `:v4.14.1-docker-alpine-3.15` | [View](variants/v4.14.1-docker-alpine-3.15) |
-| `:v4.14.1-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.14.1-docker-go-1.20.8-alpine-3.15) |
-| `:v4.14.1-docker-rootless-alpine-3.15` | [View](variants/v4.14.1-docker-rootless-alpine-3.15) |
-| `:v4.14.1-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.14.1-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.13.0-alpine-3.15` | [View](variants/v4.13.0-alpine-3.15) |
-| `:v4.13.0-docker-alpine-3.15` | [View](variants/v4.13.0-docker-alpine-3.15) |
-| `:v4.13.0-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.13.0-docker-go-1.20.8-alpine-3.15) |
-| `:v4.13.0-docker-rootless-alpine-3.15` | [View](variants/v4.13.0-docker-rootless-alpine-3.15) |
-| `:v4.13.0-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.13.0-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.12.0-alpine-3.15` | [View](variants/v4.12.0-alpine-3.15) |
-| `:v4.12.0-docker-alpine-3.15` | [View](variants/v4.12.0-docker-alpine-3.15) |
-| `:v4.12.0-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.12.0-docker-go-1.20.8-alpine-3.15) |
-| `:v4.12.0-docker-rootless-alpine-3.15` | [View](variants/v4.12.0-docker-rootless-alpine-3.15) |
-| `:v4.12.0-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.12.0-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.11.0-alpine-3.15` | [View](variants/v4.11.0-alpine-3.15) |
-| `:v4.11.0-docker-alpine-3.15` | [View](variants/v4.11.0-docker-alpine-3.15) |
-| `:v4.11.0-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.11.0-docker-go-1.20.8-alpine-3.15) |
-| `:v4.11.0-docker-rootless-alpine-3.15` | [View](variants/v4.11.0-docker-rootless-alpine-3.15) |
-| `:v4.11.0-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.11.0-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.10.1-alpine-3.15` | [View](variants/v4.10.1-alpine-3.15) |
-| `:v4.10.1-docker-alpine-3.15` | [View](variants/v4.10.1-docker-alpine-3.15) |
-| `:v4.10.1-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.10.1-docker-go-1.20.8-alpine-3.15) |
-| `:v4.10.1-docker-rootless-alpine-3.15` | [View](variants/v4.10.1-docker-rootless-alpine-3.15) |
-| `:v4.10.1-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.10.1-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.9.1-alpine-3.15` | [View](variants/v4.9.1-alpine-3.15) |
-| `:v4.9.1-docker-alpine-3.15` | [View](variants/v4.9.1-docker-alpine-3.15) |
-| `:v4.9.1-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.9.1-docker-go-1.20.8-alpine-3.15) |
-| `:v4.9.1-docker-rootless-alpine-3.15` | [View](variants/v4.9.1-docker-rootless-alpine-3.15) |
-| `:v4.9.1-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.9.1-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.8.3-alpine-3.15` | [View](variants/v4.8.3-alpine-3.15) |
-| `:v4.8.3-docker-alpine-3.15` | [View](variants/v4.8.3-docker-alpine-3.15) |
-| `:v4.8.3-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.8.3-docker-go-1.20.8-alpine-3.15) |
-| `:v4.8.3-docker-rootless-alpine-3.15` | [View](variants/v4.8.3-docker-rootless-alpine-3.15) |
-| `:v4.8.3-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.8.3-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.7.1-alpine-3.15` | [View](variants/v4.7.1-alpine-3.15) |
-| `:v4.7.1-docker-alpine-3.15` | [View](variants/v4.7.1-docker-alpine-3.15) |
-| `:v4.7.1-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.7.1-docker-go-1.20.8-alpine-3.15) |
-| `:v4.7.1-docker-rootless-alpine-3.15` | [View](variants/v4.7.1-docker-rootless-alpine-3.15) |
-| `:v4.7.1-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.7.1-docker-rootless-go-1.20.8-alpine-3.15) |
-| `:v4.6.1-alpine-3.15` | [View](variants/v4.6.1-alpine-3.15) |
-| `:v4.6.1-docker-alpine-3.15` | [View](variants/v4.6.1-docker-alpine-3.15) |
-| `:v4.6.1-docker-go-1.20.8-alpine-3.15` | [View](variants/v4.6.1-docker-go-1.20.8-alpine-3.15) |
-| `:v4.6.1-docker-rootless-alpine-3.15` | [View](variants/v4.6.1-docker-rootless-alpine-3.15) |
-| `:v4.6.1-docker-rootless-go-1.20.8-alpine-3.15` | [View](variants/v4.6.1-docker-rootless-go-1.20.8-alpine-3.15) |
+| `:v4.16.1`, `:latest` | [View](variants/v4.16.1) |
+| `:v4.16.1-docker` | [View](variants/v4.16.1-docker) |
+| `:v4.16.1-docker-go-1.20.8` | [View](variants/v4.16.1-docker-go-1.20.8) |
+| `:v4.16.1-docker-rootless` | [View](variants/v4.16.1-docker-rootless) |
+| `:v4.16.1-docker-rootless-go-1.20.8` | [View](variants/v4.16.1-docker-rootless-go-1.20.8) |
+| `:v4.15.0` | [View](variants/v4.15.0) |
+| `:v4.15.0-docker` | [View](variants/v4.15.0-docker) |
+| `:v4.15.0-docker-go-1.20.8` | [View](variants/v4.15.0-docker-go-1.20.8) |
+| `:v4.15.0-docker-rootless` | [View](variants/v4.15.0-docker-rootless) |
+| `:v4.15.0-docker-rootless-go-1.20.8` | [View](variants/v4.15.0-docker-rootless-go-1.20.8) |
+| `:v4.14.1` | [View](variants/v4.14.1) |
+| `:v4.14.1-docker` | [View](variants/v4.14.1-docker) |
+| `:v4.14.1-docker-go-1.20.8` | [View](variants/v4.14.1-docker-go-1.20.8) |
+| `:v4.14.1-docker-rootless` | [View](variants/v4.14.1-docker-rootless) |
+| `:v4.14.1-docker-rootless-go-1.20.8` | [View](variants/v4.14.1-docker-rootless-go-1.20.8) |
+| `:v4.13.0` | [View](variants/v4.13.0) |
+| `:v4.13.0-docker` | [View](variants/v4.13.0-docker) |
+| `:v4.13.0-docker-go-1.20.8` | [View](variants/v4.13.0-docker-go-1.20.8) |
+| `:v4.13.0-docker-rootless` | [View](variants/v4.13.0-docker-rootless) |
+| `:v4.13.0-docker-rootless-go-1.20.8` | [View](variants/v4.13.0-docker-rootless-go-1.20.8) |
+| `:v4.12.0` | [View](variants/v4.12.0) |
+| `:v4.12.0-docker` | [View](variants/v4.12.0-docker) |
+| `:v4.12.0-docker-go-1.20.8` | [View](variants/v4.12.0-docker-go-1.20.8) |
+| `:v4.12.0-docker-rootless` | [View](variants/v4.12.0-docker-rootless) |
+| `:v4.12.0-docker-rootless-go-1.20.8` | [View](variants/v4.12.0-docker-rootless-go-1.20.8) |
+| `:v4.11.0` | [View](variants/v4.11.0) |
+| `:v4.11.0-docker` | [View](variants/v4.11.0-docker) |
+| `:v4.11.0-docker-go-1.20.8` | [View](variants/v4.11.0-docker-go-1.20.8) |
+| `:v4.11.0-docker-rootless` | [View](variants/v4.11.0-docker-rootless) |
+| `:v4.11.0-docker-rootless-go-1.20.8` | [View](variants/v4.11.0-docker-rootless-go-1.20.8) |
+| `:v4.10.1` | [View](variants/v4.10.1) |
+| `:v4.10.1-docker` | [View](variants/v4.10.1-docker) |
+| `:v4.10.1-docker-go-1.20.8` | [View](variants/v4.10.1-docker-go-1.20.8) |
+| `:v4.10.1-docker-rootless` | [View](variants/v4.10.1-docker-rootless) |
+| `:v4.10.1-docker-rootless-go-1.20.8` | [View](variants/v4.10.1-docker-rootless-go-1.20.8) |
+| `:v4.9.1` | [View](variants/v4.9.1) |
+| `:v4.9.1-docker` | [View](variants/v4.9.1-docker) |
+| `:v4.9.1-docker-go-1.20.8` | [View](variants/v4.9.1-docker-go-1.20.8) |
+| `:v4.9.1-docker-rootless` | [View](variants/v4.9.1-docker-rootless) |
+| `:v4.9.1-docker-rootless-go-1.20.8` | [View](variants/v4.9.1-docker-rootless-go-1.20.8) |
+| `:v4.8.3` | [View](variants/v4.8.3) |
+| `:v4.8.3-docker` | [View](variants/v4.8.3-docker) |
+| `:v4.8.3-docker-go-1.20.8` | [View](variants/v4.8.3-docker-go-1.20.8) |
+| `:v4.8.3-docker-rootless` | [View](variants/v4.8.3-docker-rootless) |
+| `:v4.8.3-docker-rootless-go-1.20.8` | [View](variants/v4.8.3-docker-rootless-go-1.20.8) |
+| `:v4.7.1` | [View](variants/v4.7.1) |
+| `:v4.7.1-docker` | [View](variants/v4.7.1-docker) |
+| `:v4.7.1-docker-go-1.20.8` | [View](variants/v4.7.1-docker-go-1.20.8) |
+| `:v4.7.1-docker-rootless` | [View](variants/v4.7.1-docker-rootless) |
+| `:v4.7.1-docker-rootless-go-1.20.8` | [View](variants/v4.7.1-docker-rootless-go-1.20.8) |
+| `:v4.6.1` | [View](variants/v4.6.1) |
+| `:v4.6.1-docker` | [View](variants/v4.6.1-docker) |
+| `:v4.6.1-docker-go-1.20.8` | [View](variants/v4.6.1-docker-go-1.20.8) |
+| `:v4.6.1-docker-rootless` | [View](variants/v4.6.1-docker-rootless) |
+| `:v4.6.1-docker-rootless-go-1.20.8` | [View](variants/v4.6.1-docker-rootless-go-1.20.8) |
 
-Base variants include `npm 8` and `nodejs 16` (to run `code-server`), `pwsh`, and basic tools. E.g. `v4.16.1-alpine-3.15`
+Base variants are based on `alpine`, and include `npm 8` and `nodejs 16` (to run `code-server`), `pwsh`, and basic tools. E.g. `v4.16.1`
 
 Incremental variants include additional tools and their `code` extensions:
 
@@ -79,7 +79,7 @@ Incremental variants include additional tools and their `code` extensions:
 ### Base variant(s)
 
 ```sh
-docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-alpine-3.15
+docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1
 # code-server is now available at http://127.0.0.1:8080. To login, use the password in the config file: --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
 docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 ```
@@ -87,13 +87,13 @@ docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 To disable password authentication, use `--auth=none`:
 
 ```sh
-docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-alpine-3.15 --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
+docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1 --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
 ```
 
 ### `docker` variant(s)
 
 ```sh
-docker run --name code-server --rm -it --privileged -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker-alpine-3.15
+docker run --name code-server --rm -it --privileged -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker
 # code-server is now available at http://127.0.0.1:8080. To login, use the password in the config file:
 docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 ```
@@ -101,7 +101,7 @@ docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 To disable password authentication, use `--auth=none`:
 
 ```sh
-docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker-alpine-3.15 --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
+docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
 ```
 
 #### docker buildx
@@ -129,7 +129,7 @@ docker buildx build ...
 ### `docker-rootless` variant(s)
 
 ```sh
-docker run --name code-server --rm -it --privileged -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker-rootless-alpine-3.15
+docker run --name code-server --rm -it --privileged -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker-rootless
 # code-server is now available at http://127.0.0.1:8080. To login, use the password in the config file:
 docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 ```
@@ -137,7 +137,7 @@ docker exec code-server sh -c 'cat ~/.config/code-server/config.yaml'
 To start code-server without password authentication, use `--auth=none`:
 
 ```sh
-docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker-rootless-alpine-3.15 --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
+docker run --name code-server --rm -it -p 127.0.0.1:8080:8080 theohbrothers/docker-code-server:v4.16.1-docker-rootless --bind-addr=0.0.0.0:8080 --auth=none --disable-telemetry --disable-update-check
 ```
 
 To build multi-arch images using `docker buildx`, see [here](#docker-buildx).

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -37,12 +37,10 @@ $VARIANTS = @(
                     components = $subVariant['components']
                     job_group_key = $variant['package_version']
                 }
-                # Docker image tag. E.g. 'v2.3.0-alpine-3.6'
+                # Docker image tag. E.g. 'v2.17.0[-component..]'
                 tag = @(
                         "v$( $variant['package_version'] )"
                         $subVariant['components'] | ? { $_ }
-                        $variant['distro']
-                        $variant['distro_version']
                 ) -join '-'
                 tag_as_latest = if ($variant['package_version'] -eq $local:VARIANTS_MATRIX[0]['package_version'] -and $subVariant['components'].Count -eq 0) { $true } else { $false }
             }

--- a/generate/templates/README.md.ps1
+++ b/generate/templates/README.md.ps1
@@ -26,7 +26,7 @@ $(
     }
 }) -join ''
 )
-Base variants include ``npm 8`` and ``nodejs 16`` (to run ``code-server``), ``pwsh``, and basic tools. E.g. ``$( $VARIANTS | ? { $_['tag_as_latest'] } | Select-Object -First 1 | Select-Object -ExpandProperty tag )``
+Base variants are based on ``alpine``, and include ``npm 8`` and ``nodejs 16`` (to run ``code-server``), ``pwsh``, and basic tools. E.g. ``$( $VARIANTS | ? { $_['tag_as_latest'] } | Select-Object -First 1 | Select-Object -ExpandProperty tag )``
 
 Incremental variants include additional tools and their ``code`` extensions:
 

--- a/variants/v4.10.1-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.10.1-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.10.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.10.1-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.10.1-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.10.1-docker-go-1.20.8/settings.json
+++ b/variants/v4.10.1-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.10.1-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.10.1-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.10.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.10.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.10.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.10.1-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.10.1-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.10.1-docker-rootless/Dockerfile
+++ b/variants/v4.10.1-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.10.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.10.1-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.10.1-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.10.1-docker-rootless/settings.json
+++ b/variants/v4.10.1-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.10.1-docker/Dockerfile
+++ b/variants/v4.10.1-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.10.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.10.1-docker/docker-entrypoint.sh
+++ b/variants/v4.10.1-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.10.1-docker/settings.json
+++ b/variants/v4.10.1-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.10.1/Dockerfile
+++ b/variants/v4.10.1/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.10.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.10.1/docker-entrypoint.sh
+++ b/variants/v4.10.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.10.1/settings.json
+++ b/variants/v4.10.1/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.11.0-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.11.0-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.11.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.11.0-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.11.0-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.11.0-docker-go-1.20.8/settings.json
+++ b/variants/v4.11.0-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.11.0-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.11.0-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.11.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.11.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.11.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.11.0-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.11.0-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.11.0-docker-rootless/Dockerfile
+++ b/variants/v4.11.0-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.11.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.11.0-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.11.0-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.11.0-docker-rootless/settings.json
+++ b/variants/v4.11.0-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.11.0-docker/Dockerfile
+++ b/variants/v4.11.0-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.11.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.11.0-docker/docker-entrypoint.sh
+++ b/variants/v4.11.0-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.11.0-docker/settings.json
+++ b/variants/v4.11.0-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.11.0/Dockerfile
+++ b/variants/v4.11.0/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.11.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.11.0/docker-entrypoint.sh
+++ b/variants/v4.11.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.11.0/settings.json
+++ b/variants/v4.11.0/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.12.0-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.12.0-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.12.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.12.0-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.12.0-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.12.0-docker-go-1.20.8/settings.json
+++ b/variants/v4.12.0-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.12.0-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.12.0-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.12.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.12.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.12.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.12.0-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.12.0-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.12.0-docker-rootless/Dockerfile
+++ b/variants/v4.12.0-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.12.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.12.0-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.12.0-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.12.0-docker-rootless/settings.json
+++ b/variants/v4.12.0-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.12.0-docker/Dockerfile
+++ b/variants/v4.12.0-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.12.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.12.0-docker/docker-entrypoint.sh
+++ b/variants/v4.12.0-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.12.0-docker/settings.json
+++ b/variants/v4.12.0-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.12.0/Dockerfile
+++ b/variants/v4.12.0/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.12.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.12.0/docker-entrypoint.sh
+++ b/variants/v4.12.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.12.0/settings.json
+++ b/variants/v4.12.0/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.13.0-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.13.0-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.13.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.13.0-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.13.0-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.13.0-docker-go-1.20.8/settings.json
+++ b/variants/v4.13.0-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.13.0-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.13.0-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.13.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.13.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.13.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.13.0-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.13.0-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.13.0-docker-rootless/Dockerfile
+++ b/variants/v4.13.0-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.13.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.13.0-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.13.0-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.13.0-docker-rootless/settings.json
+++ b/variants/v4.13.0-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.13.0-docker/Dockerfile
+++ b/variants/v4.13.0-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.13.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.13.0-docker/docker-entrypoint.sh
+++ b/variants/v4.13.0-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.13.0-docker/settings.json
+++ b/variants/v4.13.0-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.13.0/Dockerfile
+++ b/variants/v4.13.0/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.13.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.13.0/docker-entrypoint.sh
+++ b/variants/v4.13.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.13.0/settings.json
+++ b/variants/v4.13.0/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.14.1-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.14.1-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.14.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.14.1-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.14.1-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.14.1-docker-go-1.20.8/settings.json
+++ b/variants/v4.14.1-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.14.1-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.14.1-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.14.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.14.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.14.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.14.1-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.14.1-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.14.1-docker-rootless/Dockerfile
+++ b/variants/v4.14.1-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.14.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.14.1-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.14.1-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.14.1-docker-rootless/settings.json
+++ b/variants/v4.14.1-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.14.1-docker/Dockerfile
+++ b/variants/v4.14.1-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.14.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.14.1-docker/docker-entrypoint.sh
+++ b/variants/v4.14.1-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.14.1-docker/settings.json
+++ b/variants/v4.14.1-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.14.1/Dockerfile
+++ b/variants/v4.14.1/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.14.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.14.1/docker-entrypoint.sh
+++ b/variants/v4.14.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.14.1/settings.json
+++ b/variants/v4.14.1/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.15.0-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.15.0-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.15.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.15.0-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.15.0-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.15.0-docker-go-1.20.8/settings.json
+++ b/variants/v4.15.0-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.15.0-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.15.0-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.15.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.15.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.15.0-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.15.0-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.15.0-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.15.0-docker-rootless/Dockerfile
+++ b/variants/v4.15.0-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.15.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.15.0-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.15.0-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.15.0-docker-rootless/settings.json
+++ b/variants/v4.15.0-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.15.0-docker/Dockerfile
+++ b/variants/v4.15.0-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.15.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.15.0-docker/docker-entrypoint.sh
+++ b/variants/v4.15.0-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.15.0-docker/settings.json
+++ b/variants/v4.15.0-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.15.0/Dockerfile
+++ b/variants/v4.15.0/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.15.0 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.15.0/docker-entrypoint.sh
+++ b/variants/v4.15.0/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.15.0/settings.json
+++ b/variants/v4.15.0/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.16.1-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.16.1-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.16.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.16.1-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.16.1-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.16.1-docker-go-1.20.8/settings.json
+++ b/variants/v4.16.1-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.16.1-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.16.1-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.16.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.16.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.16.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.16.1-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.16.1-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.16.1-docker-rootless/Dockerfile
+++ b/variants/v4.16.1-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.16.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.16.1-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.16.1-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.16.1-docker-rootless/settings.json
+++ b/variants/v4.16.1-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.16.1-docker/Dockerfile
+++ b/variants/v4.16.1-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.16.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.16.1-docker/docker-entrypoint.sh
+++ b/variants/v4.16.1-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.16.1-docker/settings.json
+++ b/variants/v4.16.1-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.16.1/Dockerfile
+++ b/variants/v4.16.1/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.16.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.16.1/docker-entrypoint.sh
+++ b/variants/v4.16.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.16.1/settings.json
+++ b/variants/v4.16.1/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.6.1-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.6.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1-docker-go-1.20.8/settings.json
+++ b/variants/v4.6.1-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.6.1-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.6.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.6.1-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1-docker-rootless/Dockerfile
+++ b/variants/v4.6.1-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.6.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1-docker-rootless/settings.json
+++ b/variants/v4.6.1-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1-docker/Dockerfile
+++ b/variants/v4.6.1-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.6.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1-docker/docker-entrypoint.sh
+++ b/variants/v4.6.1-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1-docker/settings.json
+++ b/variants/v4.6.1-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.6.1/Dockerfile
+++ b/variants/v4.6.1/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.6.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.6.1/docker-entrypoint.sh
+++ b/variants/v4.6.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.6.1/settings.json
+++ b/variants/v4.6.1/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.7.1-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.7.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-docker-go-1.20.8/settings.json
+++ b/variants/v4.7.1-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.7.1-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.7.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.7.1-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-docker-rootless/Dockerfile
+++ b/variants/v4.7.1-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.7.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-docker-rootless/settings.json
+++ b/variants/v4.7.1-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1-docker/Dockerfile
+++ b/variants/v4.7.1-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.7.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1-docker/docker-entrypoint.sh
+++ b/variants/v4.7.1-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1-docker/settings.json
+++ b/variants/v4.7.1-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.7.1/Dockerfile
+++ b/variants/v4.7.1/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.7.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.7.1/docker-entrypoint.sh
+++ b/variants/v4.7.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.7.1/settings.json
+++ b/variants/v4.7.1/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.8.3-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-docker-go-1.20.8/settings.json
+++ b/variants/v4.8.3-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.8.3-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.8.3-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-docker-rootless/Dockerfile
+++ b/variants/v4.8.3-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-docker-rootless/settings.json
+++ b/variants/v4.8.3-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3-docker/Dockerfile
+++ b/variants/v4.8.3-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3-docker/docker-entrypoint.sh
+++ b/variants/v4.8.3-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3-docker/settings.json
+++ b/variants/v4.8.3-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.8.3/Dockerfile
+++ b/variants/v4.8.3/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.8.3 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.8.3/docker-entrypoint.sh
+++ b/variants/v4.8.3/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.8.3/settings.json
+++ b/variants/v4.8.3/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-docker-go-1.20.8/Dockerfile
+++ b/variants/v4.9.1-docker-go-1.20.8/Dockerfile
@@ -1,0 +1,335 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.9.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-docker-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-docker-go-1.20.8/settings.json
+++ b/variants/v4.9.1-docker-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-docker-rootless-go-1.20.8/Dockerfile
+++ b/variants/v4.9.1-docker-rootless-go-1.20.8/Dockerfile
@@ -1,0 +1,379 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.9.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Install golang binaries from official golang image
+# See: https://go.dev/dl/
+USER root
+ENV GOLANG_VERSION 1.20.8
+ENV PATH=/usr/local/go/bin:$PATH
+COPY --from=golang:1.20.8-alpine /usr/local/go /usr/local/go
+RUN go version
+
+# Install development tools
+RUN set -eux; \
+    export GOBIN=/usr/local/bin; \
+    go install github.com/go-delve/delve/cmd/dlv@v1.20.1; \
+    dlv version; \
+    go install golang.org/x/tools/gopls@v0.11.0; \
+    gopls version; \
+    rm -rf ~/go;
+
+# Install extensions
+USER user
+RUN code-server --install-extension golang.go@0.38.0
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker-rootless-go-1.20.8/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-docker-rootless-go-1.20.8/settings.json
+++ b/variants/v4.9.1-docker-rootless-go-1.20.8/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-docker-rootless/Dockerfile
+++ b/variants/v4.9.1-docker-rootless/Dockerfile
@@ -1,0 +1,358 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.9.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install rootless docker. See: https://docs.docker.com/engine/security/rootless/
+USER root
+RUN apk add --no-cache iproute2 fuse-overlayfs
+RUN set -eux; \
+    echo user:100000:65536 >> /etc/subuid; \
+    echo user:100000:65536 >> /etc/subgid
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.23.tgz'; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker-rootless-extras.tgz; \
+    tar -xvf docker-rootless-extras.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin \
+        'docker-rootless-extras/rootlesskit' \
+        'docker-rootless-extras/rootlesskit-docker-proxy' \
+        'docker-rootless-extras/vpnkit' \
+    ; \
+    ls -al /usr/local/bin; \
+    rm -v docker-rootless-extras.tgz; \
+    rootlesskit --version; \
+    vpnkit --version
+# Create XDG_RUNTIME_DIR
+RUN mkdir /run/user && chmod 1777 /run/user
+# Create /var/lib/docker
+RUN mkdir -p /home/user/.local/share/docker && chown user:user /home/user/.local/share/docker
+VOLUME /home/user/.local/share/docker
+# Set env vars
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV DOCKER_HOST=unix:///run/user/1000/docker.sock
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-docker-rootless/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker-rootless/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    # Start rootless docker
+    # See: https://github.com/moby/moby/blob/v20.10.22/contrib/dockerd-rootless.sh
+    # See: https://github.com/docker-library/docker/blob/master/20.10/dind/dockerd-entrypoint.sh
+    echo "Starting rootless dockerd"
+    rootlesskit \
+        --net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+        --mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+        --disable-host-loopback \
+        --port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
+        --copy-up=/etc \
+        --copy-up=/run \
+        --propagation=rslave \
+        ${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
+        dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-docker-rootless/settings.json
+++ b/variants/v4.9.1-docker-rootless/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1-docker/Dockerfile
+++ b/variants/v4.9.1-docker/Dockerfile
@@ -1,0 +1,314 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.9.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Install docker
+# See: https://github.com/moby/moby/blob/v20.10.22/project/PACKAGERS.md
+# Install docker-cli dependencies
+USER root
+RUN apk add --no-cache \
+        ca-certificates \
+        git \
+        # Workaround for golang 1.15 not producing static binaries. See: https://github.com/containerd/containerd/issues/5824
+        libc6-compat \
+        openssh-client
+# Install dockerd dependencies
+RUN apk add --no-cache \
+        btrfs-progs \
+        e2fsprogs \
+        e2fsprogs-extra \
+        ip6tables \
+        iptables \
+        openssl \
+        pigz \
+        shadow-uidmap \
+        xfsprogs \
+        xz \
+        zfs
+# Add userns-remap support. See: https://docs.docker.com/engine/security/userns-remap/
+RUN set -eux; \
+    addgroup -S dockremap; \
+    adduser -S -G dockremap dockremap; \
+    echo 'dockremap:231072:65536' >> /etc/subuid; \
+    echo 'dockremap:231072:65536' >> /etc/subgid
+# Install docker
+RUN set -eux; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL='https://download.docker.com/linux/static/stable/x86_64/docker-20.10.23.tgz'; \
+            ;; \
+        'armhf') \
+            URL='https://download.docker.com/linux/static/stable/armel/docker-20.10.23.tgz'; \
+            ;; \
+        'armv7') \
+            URL='https://download.docker.com/linux/static/stable/armhf/docker-20.10.23.tgz'; \
+            ;; \
+        'aarch64') \
+            URL='https://download.docker.com/linux/static/stable/aarch64/docker-20.10.23.tgz'; \
+            ;; \
+        # These architectures are no longer supported as of docker 20.10.x
+        # 'ppc64le') \
+        # 	URL='https://download.docker.com/linux/static/stable/ppc64le/docker-20.10.23.tgz'; \
+        # 	;; \
+        # 's390x') \
+        # 	URL='https://download.docker.com/linux/static/stable/s390x/docker-20.10.23.tgz'; \
+        # 	;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    wget -q "$URL" -O docker.tgz; \
+    tar -xvf docker.tgz --strip-components=1 --no-same-owner --no-same-permissions -C /usr/local/bin; \
+    ls -al /usr/local/bin; \
+    rm -v docker.tgz; \
+    containerd --version; \
+    ctr --version; \
+    docker --version; \
+    dockerd --version; \
+    runc --version
+# Install bash completion
+RUN wget -q https://raw.githubusercontent.com/docker/cli/v20.10.23/contrib/completion/bash/docker -O /usr/share/bash-completion/completions/docker
+# Post-install docker. See: https://docs.docker.com/engine/install/linux-postinstall/
+RUN set -eux; \
+    addgroup docker; \
+    adduser user docker;
+VOLUME /var/lib/docker
+
+# Install docker-compose v1 (deprecated, but for backward compatibility)
+USER root
+RUN apk add --no-cache docker-compose
+
+# Install docker-compose
+RUN set -eux; \
+    DOCKER_COMPOSE_VERSION=v2.17.3; \
+    case "$( uname -m )" in \
+        'x86') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'x86_64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-x86_64; \
+            SHA256=6abb771a438b8ef82b0ff0ef0e2e404032699104c3c40c59cd174b56214876c3; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv6; \
+            SHA256=e8c20e7e02faa623839ccb2af725ae0b343eafaf836b2386579e35c598d7468a; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-armv7; \
+            SHA256=72c26a8ab6a519bd9c645a314d6ed33ed694efeda3f787123806990124446fe8; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-aarch64; \
+            SHA256=07bdced6f502ab24b481f46aa6b205f97e2256e5cb11279648ac9c088220a38d; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-ppc64le; \
+            SHA256=06075ea6594e42fd62360c029ed2b7cf294e8a50428cc3c8f0e022a68f672660; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-riscv64; \
+            SHA256=51c3e1b631be5845aecc9a66d4d0525c94dfec4d20a4ccf535a7f960f780e9f2; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-s390x; \
+            SHA256=666a07a5605e985ac96608a315cdae8151e72196733147dd81b61dd42c0777fe; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-compose; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-compose /usr/libexec/docker/cli-plugins/docker-compose; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose; \
+    docker compose version; \
+    :
+
+# Install docker-buildx
+RUN set -eux; \
+    DOCKER_BUILDX_VERSION=v0.11.0; \
+    case "$( uname -m )" in \
+        'x86_64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64; \
+            SHA256=ec2c9da22c3b733ad96d6a6897750153d884f1b2b86f2864ee5f743ce931055d; \
+            ;; \
+        'armhf') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v6; \
+            SHA256=a925462288a55b709a42431fe39bb0e67f033961f02a4754897c4a388355feea; \
+            ;; \
+        'armv7l') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm-v7; \
+            SHA256=e3f18a0d10346d8e53aff743fccfc0b95e45dc0235c3b0b72b49d3452c72b9e0; \
+            ;; \
+        'aarch64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-arm64; \
+            SHA256=e50f34f8feb7004407f826a375090bec6191891c473347b41b05cf5864bc5240; \
+            ;; \
+        'ppc64le') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-ppc64le; \
+            SHA256=de8670ab6b2c34feb32289d04af07014bb4517de879d1fdb6e31a00da28f1df4; \
+            ;; \
+        'riscv64') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-riscv64; \
+            SHA256=a07ad5791d6e60094e38147ef5f5eac406b2692aa380eae5ac866bde91bcdc89; \
+            ;; \
+        's390x') \
+            URL=https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-s390x; \
+            SHA256=fc1a57b9fb69f7736908bbea94013eb17b5ae03cd5ed99b0bd61e223f9b6e4a7; \
+            ;; \
+        *) \
+            echo "Architecture not supported"; \
+            exit 1; \
+            ;; \
+    esac; \
+    FILE=docker-buildx; \
+    wget -q "$URL" -O "$FILE"; \
+    echo "$SHA256  $FILE" | sha256sum -c -; \
+    mkdir -pv /usr/libexec/docker/cli-plugins; \
+    mv -v docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx; \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx; \
+    docker buildx version; \
+    :
+
+# Install binary tool(s)
+RUN set -eux; \
+    wget https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 -O container-diff; \
+    sha256sum container-diff | grep '^818c219ce9f9670cd5c766b9da5036cf75bbf98bc99eb258f5e8f90e80367c88 '; \
+    mv container-diff /usr/local/bin/container-diff; \
+    chmod +x /usr/local/bin/container-diff; \
+    container-diff version
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1-docker/docker-entrypoint.sh
+++ b/variants/v4.9.1-docker/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+    echo "Starting dockerd"
+    sudo rm -fv /var/run/docker.pid
+    sudo dockerd &
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1-docker/settings.json
+++ b/variants/v4.9.1-docker/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}

--- a/variants/v4.9.1/Dockerfile
+++ b/variants/v4.9.1/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+RUN set -eu; \
+    echo "TARGETPLATFORM=$TARGETPLATFORM"; \
+    echo "TARGETOS=$TARGETOS"; \
+    echo "TARGETARCH=$TARGETARCH"; \
+    echo "TARGETVARIANT=$TARGETVARIANT"; \
+    echo "BUILDPLATFORM=$BUILDPLATFORM"; \
+    echo "BUILDOS=$BUILDOS"; \
+    echo "BUILDARCH=$BUILDARCH"; \
+    echo "BUILDVARIANT=$BUILDVARIANT";
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    DEPS='alpine-sdk bash libstdc++ libc6-compat python3' \
+    && apk add --no-cache $DEPS \
+    # Constraint to npm 8, or else npm will fail with 'npm ERR! python is not a valid npm option'. See: https://stackoverflow.com/questions/74522956/python-is-not-a-valid-npm-option and https://jubianchi.github.io/semver-check/#/~8/8
+    && apk add --no-cache 'npm~8' 'nodejs~16' \
+    && npm config set python python3 \
+    && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --global code-server@4.9.1 --unsafe-perm \
+    # Fix missing dependencies. See: https://github.com/coder/code-server/issues/5530
+    && cd /usr/local/lib/node_modules/code-server/lib/vscode && GITHUB_TOKEN=$( cat /run/secrets/GITHUB_TOKEN ) npm install --legacy-peer-deps \
+    && code-server --version \
+    && apk del $DEPS
+
+# Install tools
+RUN apk add --no-cache bash bash-completion ca-certificates curl gnupg git git-lfs github-cli iotop jq less lsblk make nano openssh-client openssl p7zip rsync tree yq
+
+# Install pwsh
+# See: https://learn.microsoft.com/en-us/powershell/scripting/install/install-alpine?view=powershell-7.3
+RUN apk add --no-cache \
+    ca-certificates \
+    less \
+    ncurses-terminfo-base \
+    krb5-libs \
+    libgcc \
+    libintl \
+    libssl1.1 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    icu-libs \
+    curl
+RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
+RUN mkdir -p /opt/microsoft/powershell/7 \
+    && curl -sSL https://github.com/PowerShell/PowerShell/releases/download/v7.2.8/powershell-7.2.8-linux-alpine-x64.tar.gz | tar -C /opt/microsoft/powershell/7 -zxf - \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+# Disable telemetry for powershell 7.0.0 and above and .NET core: https://github.com/PowerShell/PowerShell/issues/16234#issuecomment-942139350
+ENV POWERSHELL_CLI_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
+ENV POWERSHELL_UPDATECHECK=Off
+ENV POWERSHELL_UPDATECHECK_OPTOUT=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_TELEMETRY_OPTOUT=1
+ENV COMPlus_EnableDiagnostics=0
+RUN pwsh -version
+# Install pwsh module(s)
+RUN pwsh -c 'Install-Module Pester -Force -Scope AllUsers -MinimumVersion 4.0.0 -MaximumVersion 4.10.1 -ErrorAction Stop'
+
+RUN apk add --no-cache sudo
+RUN adduser -u 1000 --gecos '' -D user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user
+
+# Install common extensions
+USER user
+# beautify - code formatter
+RUN code-server --install-extension hookyqr.beautify@1.4.11
+# docker
+RUN code-server --install-extension ms-azuretools.vscode-docker@1.18.0
+# firefox
+RUN code-server --install-extension firefox-devtools.vscode-firefox-debug@2.9.1
+# git
+RUN code-server --install-extension donjayamanne.githistory@0.6.19
+RUN code-server --install-extension eamodio.gitlens@11.6.0
+# github. Install the latest compatible version
+RUN code-server --install-extension github.vscode-pull-request-github
+# gitlab
+RUN code-server --install-extension gitlab.gitlab-workflow@3.60.0
+# jinja
+RUN code-server --install-extension samuelcolvin.jinjahtml@0.16.0
+RUN code-server --install-extension wholroyd.jinja@0.0.8
+# kubernetes
+RUN code-server --install-extension ms-kubernetes-tools.vscode-kubernetes-tools@1.3.11
+# markdown
+RUN code-server --install-extension bierner.markdown-preview-github-styles@0.1.6
+RUN code-server --install-extension DavidAnson.vscode-markdownlint@0.43.2
+# prettier - code formatter
+RUN code-server --install-extension esbenp.prettier-vscode@9.0.0
+# pwsh
+RUN code-server --install-extension ms-vscode.powershell@2021.12.0
+# svg
+RUN code-server --install-extension jock.svg@1.4.17
+# terraform
+RUN code-server --install-extension hashicorp.terraform@2.14.0
+# toml
+RUN code-server --install-extension bungcip.better-toml@0.3.2
+# vscode
+RUN code-server --install-extension vscode-icons-team.vscode-icons@11.13.0
+# xml
+RUN code-server --install-extension redhat.vscode-xml@0.18.0
+# yaml
+RUN code-server --install-extension redhat.vscode-yaml@1.9.1
+
+# Add a default settings.json
+USER user
+COPY --chown=1000:1000 settings.json /home/user/.local/share/code-server/User/settings.json
+
+# Remove the default code-server config file created when extensions are installed
+USER user
+RUN rm -fv ~/.config/code-server/config.yaml
+
+# Symlink code to code-server
+USER root
+RUN ln -sfn /usr/local/bin/code-server /usr/local/bin/code
+
+USER root
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV LANG=en_US.UTF-8
+USER user
+WORKDIR /home/user
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "--bind-addr=0.0.0.0:8080", "--disable-telemetry", "--disable-update-check" ]

--- a/variants/v4.9.1/docker-entrypoint.sh
+++ b/variants/v4.9.1/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# See: https://github.com/docker-library/official-images#consistency
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- code-server "$@"
+fi
+if [ "$1" = 'code-server' ]; then
+
+    echo "Starting code-server"
+    exec code-server "$@"
+fi
+exec "$@"

--- a/variants/v4.9.1/settings.json
+++ b/variants/v4.9.1/settings.json
@@ -1,0 +1,24 @@
+{
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "extensions.showRecommendationsOnlyOnDemand": true,
+  "npm.fetchOnlinePackageInfo": false,
+  "telemetry.enableTelemetry": false,
+  "telemetry.telemetryLevel": "off",
+  "typescript.check.npmIsInstalled": false,
+  "typescript.disableAutomaticTypeAcquisition": false,
+  "typescript.surveys.enabled": false,
+  "workbench.enableExperiments": false,
+  "workbench.iconTheme": "vscode-icons",
+  "workbench.settings.enableNaturalLanguageSearch": false,
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.walkthroughs.openOnInstall": false,
+  "workbench.tips.enabled": false,
+
+  // Extension-specific
+  "gitlens.showWelcomeOnInstall": false,
+  "gitlens.showWhatsNewAfterUpgrades": false,
+  "redhat.telemetry.enabled": false,
+  "vsicons.dontShowNewVersionMessage": true,
+}


### PR DESCRIPTION
This decouples the application from the distro, and keeps the distro transparent to the user. Since all variants use the same distro, their docker tags should not need a distro suffix.
